### PR TITLE
kraken: implement pay command proxy around core lightning pay command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ build/
 *.log
 *.info
 *.exe
+
+kraken

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC=dart
 FMT=format
 ARGS="--help"
 PROBLEM=
-NAME=cln_plugin
+NAME=kraken
 
 default: fmt build
 

--- a/lib/src/kraken.dart
+++ b/lib/src/kraken.dart
@@ -19,7 +19,7 @@ class KrakenPlugin extends Plugin {
     try {
       // TODO make sure that this will trow an exception
       Map<String, dynamic> listPays = await rpc!
-          .call(method: "listpays", params: params.toListPaysRequest());
+          .call(method: "paystatus", params: params.toPaysStatusRequest());
       Map<String, dynamic> listFunds = await rpc!
           .call(method: "listfunds", params: params.toListFundsRequest());
 
@@ -77,14 +77,13 @@ class KrakenPlugin extends Plugin {
               PayResponse.fromJson(jsonDecode(jsonEncode(jsonPayload))));
       return result.toJSON() as Map<String, Object>;
     } on LNClientException catch (ex, stacktrace) {
+      request["raw_reason"] = ex.message;
       plugin.log(level: "broken", message: "error received: ${ex.message}");
       plugin.log(level: "broken", message: stacktrace.toString());
       return krakenDoctor(plugin, request);
     } catch (ex, stacktrace) {
       plugin.log(level: "broken", message: "error received: ${ex.toString()}");
       plugin.log(level: "broken", message: stacktrace.toString());
-      // TODO run the doctor command, and put the CLN exception message inside the doctor request
-      // with identifier `raw_reason`
       rethrow;
     }
   }

--- a/lib/src/model/model.dart
+++ b/lib/src/model/model.dart
@@ -1,76 +1,113 @@
 import 'package:cln_common/cln_common.dart';
+import 'package:json_annotation/json_annotation.dart';
 
+part 'model.g.dart';
+
+@JsonSerializable()
 class DoctorRequest extends Serializable {
-  final String invoice;
+  final String bolt11;
 
-  DoctorRequest(this.invoice);
+  DoctorRequest(this.bolt11);
 
   @override
   T as<T>() {
     return this as T;
   }
 
-  ListPaysRequest toListPaysRequest() => ListPaysRequest(invoice);
+  ListPaysRequest toListPaysRequest() => ListPaysRequest(bolt11);
 
   ListFundsRequest toListFundsRequest() => ListFundsRequest();
 
   // TODO implement autogenerator
-  factory DoctorRequest.fromJson(Map<String, dynamic> json) {
-    return DoctorRequest("");
-  }
+  factory DoctorRequest.fromJson(Map<String, dynamic> json) =>
+      _$DoctorRequestFromJson(json);
 
   @override
-  Map<String, dynamic> toJSON() => {};
+  Map<String, dynamic> toJSON() => _$DoctorRequestToJson(this);
 }
 
+@JsonSerializable()
 class ListPaysRequest extends Serializable {
-  final String invoice;
+  final String bolt11;
 
-  ListPaysRequest(this.invoice);
+  ListPaysRequest(this.bolt11);
 
-  // TODO implement autogenerator
-  factory ListPaysRequest.fromJson(Map<String, dynamic> json) {
-    return ListPaysRequest("");
-  }
+  factory ListPaysRequest.fromJson(Map<String, dynamic> json) =>
+      _$ListPaysRequestFromJson(json);
 
   @override
-  Map<String, dynamic> toJSON() => {};
+  Map<String, dynamic> toJSON() => _$ListPaysRequestToJson(this);
 }
 
+@JsonSerializable()
 class ListFundsRequest extends Serializable {
   ListFundsRequest();
 
+  factory ListFundsRequest.fromJson(Map<String, dynamic> json) =>
+      _$ListFundsRequestFromJson(json);
+
   @override
-  Map<String, dynamic> toJSON() => {};
+  Map<String, dynamic> toJSON() => _$ListFundsRequestToJson(this);
 }
 
+@JsonSerializable()
 class PayRequest extends Serializable {
-  PayRequest();
+  String bolt11;
 
-  factory PayRequest.fromJson(Map<String, dynamic> json) {
-    return PayRequest();
-  }
+  PayRequest(this.bolt11);
+
+  factory PayRequest.fromJson(Map<String, dynamic> json) =>
+      _$PayRequestFromJson(json);
 
   @override
-  Map<String, dynamic> toJSON() => {};
+  Map<String, dynamic> toJSON() => _$PayRequestToJson(this);
 }
 
+@JsonSerializable()
+class PayResponse extends Serializable {
+  @JsonKey(name: "payment_preimage")
+  final String paymentPreimage;
+  @JsonKey(name: "payment_hash")
+  final String paymentHash;
+  @JsonKey(name: "created_at")
+  final int createdAt;
+  final int parts;
+  final String status;
+  final String destination;
+
+  factory PayResponse.fromJson(Map<String, dynamic> json) =>
+      _$PayResponseFromJson(json);
+
+  PayResponse(this.paymentPreimage, this.paymentHash, this.createdAt,
+      this.parts, this.status, this.destination);
+
+  @override
+  Map<String, dynamic> toJSON() => _$PayResponseToJson(this);
+}
+
+@JsonSerializable()
 class FetchInvoiceRequest extends Serializable {
   String offer;
   String? msamsatoshi;
 
   FetchInvoiceRequest({required this.offer, this.msamsatoshi});
 
+  factory FetchInvoiceRequest.fromJson(Map<String, dynamic> json) =>
+      _$FetchInvoiceRequestFromJson(json);
+
   @override
-  Map<String, dynamic> toJSON() {
-    return {
-      "offer": offer,
-    };
-  }
+  Map<String, dynamic> toJSON() => _$FetchInvoiceRequestToJson(this);
 }
 
-class FetchInvoiceResponse {
+@JsonSerializable()
+class FetchInvoiceResponse extends Serializable {
   String invoice;
 
   FetchInvoiceResponse(this.invoice);
+
+  factory FetchInvoiceResponse.fromJson(Map<String, dynamic> json) =>
+      _$FetchInvoiceResponseFromJson(json);
+
+  @override
+  Map<String, dynamic> toJSON() => _$FetchInvoiceResponseToJson(this);
 }

--- a/lib/src/model/model.dart
+++ b/lib/src/model/model.dart
@@ -14,7 +14,7 @@ class DoctorRequest extends Serializable {
     return this as T;
   }
 
-  ListPaysRequest toListPaysRequest() => ListPaysRequest(bolt11);
+  PaysStatusRequest toPaysStatusRequest() => PaysStatusRequest(bolt11);
 
   ListFundsRequest toListFundsRequest() => ListFundsRequest();
 
@@ -27,12 +27,12 @@ class DoctorRequest extends Serializable {
 }
 
 @JsonSerializable()
-class ListPaysRequest extends Serializable {
+class PaysStatusRequest extends Serializable {
   final String bolt11;
 
-  ListPaysRequest(this.bolt11);
+  PaysStatusRequest(this.bolt11);
 
-  factory ListPaysRequest.fromJson(Map<String, dynamic> json) =>
+  factory PaysStatusRequest.fromJson(Map<String, dynamic> json) =>
       _$ListPaysRequestFromJson(json);
 
   @override

--- a/lib/src/model/model.dart
+++ b/lib/src/model/model.dart
@@ -54,3 +54,23 @@ class PayRequest extends Serializable {
   @override
   Map<String, dynamic> toJSON() => {};
 }
+
+class FetchInvoiceRequest extends Serializable {
+  String offer;
+  String? msamsatoshi;
+
+  FetchInvoiceRequest({required this.offer, this.msamsatoshi});
+
+  @override
+  Map<String, dynamic> toJSON() {
+    return {
+      "offer": offer,
+    };
+  }
+}
+
+class FetchInvoiceResponse {
+  String invoice;
+
+  FetchInvoiceResponse(this.invoice);
+}

--- a/lib/src/model/model.g.dart
+++ b/lib/src/model/model.g.dart
@@ -16,12 +16,12 @@ Map<String, dynamic> _$DoctorRequestToJson(DoctorRequest instance) =>
       'bolt11': instance.bolt11,
     };
 
-ListPaysRequest _$ListPaysRequestFromJson(Map<String, dynamic> json) =>
-    ListPaysRequest(
+PaysStatusRequest _$ListPaysRequestFromJson(Map<String, dynamic> json) =>
+    PaysStatusRequest(
       json['bolt11'] as String,
     );
 
-Map<String, dynamic> _$ListPaysRequestToJson(ListPaysRequest instance) =>
+Map<String, dynamic> _$ListPaysRequestToJson(PaysStatusRequest instance) =>
     <String, dynamic>{
       'bolt11': instance.bolt11,
     };

--- a/lib/src/model/model.g.dart
+++ b/lib/src/model/model.g.dart
@@ -1,0 +1,86 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+DoctorRequest _$DoctorRequestFromJson(Map<String, dynamic> json) =>
+    DoctorRequest(
+      json['bolt11'] as String,
+    );
+
+Map<String, dynamic> _$DoctorRequestToJson(DoctorRequest instance) =>
+    <String, dynamic>{
+      'bolt11': instance.bolt11,
+    };
+
+ListPaysRequest _$ListPaysRequestFromJson(Map<String, dynamic> json) =>
+    ListPaysRequest(
+      json['bolt11'] as String,
+    );
+
+Map<String, dynamic> _$ListPaysRequestToJson(ListPaysRequest instance) =>
+    <String, dynamic>{
+      'bolt11': instance.bolt11,
+    };
+
+ListFundsRequest _$ListFundsRequestFromJson(Map<String, dynamic> json) =>
+    ListFundsRequest();
+
+Map<String, dynamic> _$ListFundsRequestToJson(ListFundsRequest instance) =>
+    <String, dynamic>{};
+
+PayRequest _$PayRequestFromJson(Map<String, dynamic> json) => PayRequest(
+      json['bolt11'] as String,
+    );
+
+Map<String, dynamic> _$PayRequestToJson(PayRequest instance) =>
+    <String, dynamic>{
+      'bolt11': instance.bolt11,
+    };
+
+PayResponse _$PayResponseFromJson(Map<String, dynamic> json) => PayResponse(
+      json['payment_preimage'] as String,
+      json['payment_hash'] as String,
+      json['created_at'] as int,
+      json['parts'] as int,
+      json['status'] as String,
+      json['destination'] as String,
+    );
+
+Map<String, dynamic> _$PayResponseToJson(PayResponse instance) =>
+    <String, dynamic>{
+      'payment_preimage': instance.paymentPreimage,
+      'payment_hash': instance.paymentHash,
+      'created_at': instance.createdAt,
+      'parts': instance.parts,
+      'status': instance.status,
+      'destination': instance.destination,
+    };
+
+FetchInvoiceRequest _$FetchInvoiceRequestFromJson(Map<String, dynamic> json) =>
+    FetchInvoiceRequest(
+      offer: json['offer'] as String,
+      msamsatoshi: json['msamsatoshi'] as String?,
+    );
+
+Map<String, dynamic> _$FetchInvoiceRequestToJson(
+        FetchInvoiceRequest instance) =>
+    <String, dynamic>{
+      'offer': instance.offer,
+      'msamsatoshi': instance.msamsatoshi,
+    };
+
+FetchInvoiceResponse _$FetchInvoiceResponseFromJson(
+        Map<String, dynamic> json) =>
+    FetchInvoiceResponse(
+      json['invoice'] as String,
+    );
+
+Map<String, dynamic> _$FetchInvoiceResponseToJson(
+        FetchInvoiceResponse instance) =>
+    <String, dynamic>{
+      'invoice': instance.invoice,
+    };

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   clightning_rpc: ^0.0.2-beta.4
   cln_common: ^0.0.1-beta.1
-  cln_plugin_api: ^0.0.1-beta.1
+  cln_plugin_api: ^0.0.1-beta.2
   json_annotation: ^4.5.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,10 +7,13 @@ environment:
   sdk: '>=2.17.6 <3.0.0'
 
 dependencies:
-  clightning_rpc: ^0.0.2-beta.2
+  clightning_rpc: ^0.0.2-beta.4
   cln_common: ^0.0.1-beta.1
   cln_plugin_api: ^0.0.1-beta.1
+  json_annotation: ^4.5.0
 
 dev_dependencies:
   lints: ^2.0.0
   test: ^1.16.0
+  build_runner: ^2.0.0
+  json_serializable: ^6.2.0


### PR DESCRIPTION
Implementing pay proxy command, to read more about how many different ways to pay an invoice we have to take a look to

- https://github.com/ElementsProject/lightning/pull/5428#discussion_r921484477
- https://github.com/lightning/bolts/blob/master/11-payment-encoding.md#human-readable-part
- https://bolt12.org/bolt12.html#offers
- https://bolt12.org/bolt12.html#invoices

If this is not clear, you can generate a bolt11 and an offer and after you can try to use the pay command

Fixes https://github.com/dart-lightning/kraken/issues/4

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>